### PR TITLE
Add user guide and demo

### DIFF
--- a/clients/php/README.md
+++ b/clients/php/README.md
@@ -6,13 +6,13 @@ This documentation is for PHP specific usage of *Myanmar Tools*. For general doc
 
 Prerequisites: PHP >=7.0 and composer >= 1.0
 
-Add the dependency to your project: (Pending)
+Add the dependency to your project:
 
 ```bash
 $ composer install myanmar-tools
 ```
 
-To detect Zawgyi, create an instance of ZawgyiDetector, and call `getZawgyiProbability` with your string. Generally, if the score is greater than or equal to 0.95, you can assume the string is Zawgyi. If the score is lower or equal to 0.05, you can assume it is Unicode.
+To detect Zawgyi, create an instance of ZawgyiDetector, and call `getZawgyiProbability` with your string. Generally, if the score is greater than or equal to 0.95, you can generally assume the string is Zawgyi. If the score is lower or equal to 0.05, you can assume it is Unicode.
 
 ```
 $autoload = __DIR__.'/vendor/autoload.php';
@@ -47,7 +47,7 @@ Rabbit::zg2uni("သီဟိုဠ္မွ ဉာဏ္ႀကီးရွင္
 // output is now "သီဟိုဠ်မှ ဉာဏ်ကြီးရှင်သည် အာယုဝဍ်ဎနဆေးညွှန်းစာကို ဇလွန်ဈေးဘေးဗာဒံပင်ထက် အဓိဋ္ဌာန်လျက် ဂဃနဏဖတ်ခဲ့သည်။"
 ```
 
-For a complete working example, see [samples/php/demo.rb](../../samples/php/demo.php).
+For a complete working example, see [samples/php/Demo.php](../../samples/php/Demo.php).
 
 ## Contributing
 
@@ -55,7 +55,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/google
 
 ## License
 
-The gem is available as open source under the terms of the [Apache-2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
+The package is available as open source under the terms of the [Apache-2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
 
 ## Code of Conduct
 

--- a/samples/php/Demo.php
+++ b/samples/php/Demo.php
@@ -1,0 +1,33 @@
+<?php
+// include autoload
+$autoload = join(DIRECTORY_SEPARATOR, [__DIR__, "vendor", "autoload.php"]);
+if (!file_exists($autoload))
+    exit("Need Composer!");
+require $autoload;
+
+use Googlei18n\MyanmarTools\ZawgyiDetector;
+
+$detector = new ZawgyiDetector();
+
+// Unicode string
+$unicodeInput = 'အပြည်ပြည်ဆိုင်ရာ လူ့အခွင့်အရေး ကြေညာစာတမ်း';
+
+// Zawgyi string
+$zawgyiInput = 'အျပည္ျပည္ဆိုင္ရာ လူ႔အခြင့္အေရး ေၾကညာစာတမ္း';
+
+$unicodeScore = $detector->getZawgyiProbability($unicodeInput);
+$zawgyiScore  = $detector->getZawgyiProbability($zawgyiInput);
+
+assert($unicodeScore < 0.001);
+assert($zawgyiScore > 0.999);
+
+printf("Unicode Score: %.6f", $unicodeScore);
+echo "<br />";
+printf("Zawgyi Score: %.6f", $zawgyiScore);
+
+echo "<br />";
+
+// Convert the second string to Unicode:
+$zawgyi2UniConverted = Rabbit::zg2uni($zawgyiInput);
+assert($unicodeInput === $zawgyi2UniConverted, "Converted string is equal to unicode");
+printf("Converted Text: %s\n", $zawgyi2UniConverted);

--- a/samples/php/composer.json
+++ b/samples/php/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "googlei18n/myanmar-tools-sample",
+    "description": "Sample for how to use myanmar-tools detector",
+    "license": "MIT",
+    "keywords": [
+        "sample"
+    ],
+    "homepage": "https://developers.google.com/international",
+    "authors": [
+        {
+            "name": "googlei18n",
+            "email": "sample@gmail.com"
+        }
+    ],
+    "type": "project",
+    "require": {
+        "googlei18n/myanmar-tools": ">=0.1.0"
+    }
+}


### PR DESCRIPTION
Hi @sffc ,

Thanks for merging the PHP client to the repo. To be published the PHP package properly, I would like to address some points.

The first one is that I've upload the package to the **Packagist** with the name `googlei18n/myanmar-tools` at [here](https://packagist.org/packages/googlei18n/myanmar-tools). I would like to ask which other accounts do I need to add for package maintainer on the **Packagist**.

The second one is we need to create **version tag** (**Semantic Versining**) on the repo for the Packagist to detect and enable **stable version installation** of the package. Currently it cannot find the valid version tag and only shows `dev-master` version which is the clone of the master branch.

The third one is we need to enable **Integration services** for the **Packagist** to detect the changes on the repo automatically and instantly. We can read that [here](https://packagist.org/about). To do so, I think I've to add you package maintainer as first.
Since **Github services** are already [deprecated](https://developer.github.com/changes/2018-04-25-github-services-deprecation/), this step is not necessarily to do. **Packagist** also [plan](https://github.com/composer/packagist/issues/907) to build new way to integrate. 

As the final point I've added **demo code** and update the **usage guide**. For the version in the demo `composer.json`, I've set `>=0.1.0` for the package. But it is fine to modify as appropriate. 