### PR TITLE
Fix PHP zero "0" string error

### DIFF
--- a/clients/php/src/ZawgyiUnicodeMarkovModel.php
+++ b/clients/php/src/ZawgyiUnicodeMarkovModel.php
@@ -210,7 +210,7 @@ class ZawgyiUnicodeMarkovModel
 
     public static function ord_utf8($c)
     {
-        if (is_null($c))
+        if (is_null($c) || $c === "")
             return;
 
         $u32 = mb_convert_encoding($c, "UTF-32BE");

--- a/clients/php/src/ZawgyiUnicodeMarkovModel.php
+++ b/clients/php/src/ZawgyiUnicodeMarkovModel.php
@@ -210,7 +210,7 @@ class ZawgyiUnicodeMarkovModel
 
     public static function ord_utf8($c)
     {
-        if (empty($c))
+        if (is_null($c))
             return;
 
         $u32 = mb_convert_encoding($c, "UTF-32BE");


### PR DESCRIPTION
Php empty() function assumes "0" is empty. That's why ord_utf8 method return null and causes the exception if the input string includes "0". Now empty() is removed and add is_null and 3 equal signs check.