### PR TITLE
Use .inc instead of .h for non-header files meant for inclusion.

### DIFF
--- a/clients/cpp/.gitignore
+++ b/clients/cpp/.gitignore
@@ -9,11 +9,11 @@ Testing/
 *.so
 *.dylib
 
-build_model_h
+build_model_inc
 cmake_install.cmake
 CMakeCache.txt
 CTestTestfile.cmake
 install_manifest.txt
 Makefile
 myanmartools_test
-zawgyi_model_data.h
+zawgyi_model_data.inc

--- a/clients/cpp/CMakeLists.txt
+++ b/clients/cpp/CMakeLists.txt
@@ -42,13 +42,13 @@ file(
 )
 execute_process(COMMAND ${CMAKE_COMMAND} -E chdir _3rdParty tar xfz ../CMakeFiles/icu4c-61_1-src.tgz)
 
-add_executable(build_model_h build_model_h.cpp resources/zawgyiUnicodeModel.dat)
+add_executable(build_model_inc build_model_inc.cpp resources/zawgyiUnicodeModel.dat)
 add_custom_command(
-        OUTPUT zawgyi_model_data.h
-        COMMAND build_model_h ${CMAKE_SOURCE_DIR}/resources/zawgyiUnicodeModel.dat zawgyi_model_data.h
+        OUTPUT zawgyi_model_data.inc
+        COMMAND build_model_inc ${CMAKE_SOURCE_DIR}/resources/zawgyiUnicodeModel.dat zawgyi_model_data.inc
 )
 
-set(SOURCE_FILES zawgyi_detector.cpp public/myanmartools.h zawgyi_detector-impl.h zawgyi_model_data.h)
+set(SOURCE_FILES zawgyi_detector.cpp public/myanmartools.h zawgyi_detector-impl.h zawgyi_model_data.inc)
 include_directories(myanmartools ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/_3rdParty/icu/source/common)
 add_library(myanmartools SHARED ${SOURCE_FILES})
 target_link_libraries(myanmartools glog::glog)

--- a/clients/cpp/build_model_inc.cpp
+++ b/clients/cpp/build_model_inc.cpp
@@ -20,7 +20,7 @@
 int main(int argc, char* argv[]) {
   if (argc != 3) {
     std::cerr << "Expected 2 arguments, the paths to the input "
-      << "(zawgyiUnicodeModel.dat) and output (zawgyi_model_data.h)"
+      << "(zawgyiUnicodeModel.dat) and output (zawgyi_model_data.inc)"
       << std::endl;
     return 1;
   }

--- a/clients/cpp/zawgyi_detector.cpp
+++ b/clients/cpp/zawgyi_detector.cpp
@@ -20,7 +20,7 @@
 
 #include "public/myanmartools.h"
 #include "zawgyi_detector-impl.h"
-#include "zawgyi_model_data.h"
+#include "zawgyi_model_data.inc"
 
 using namespace google_myanmar_tools;
 


### PR DESCRIPTION
https://google.github.io/styleguide/cppguide.html#Self_contained_Headers