### PR TITLE
Simplify model data by not pretending to be a real header file.

### DIFF
--- a/clients/cpp/build_model_inc.cpp
+++ b/clients/cpp/build_model_inc.cpp
@@ -32,23 +32,15 @@ int main(int argc, char* argv[]) {
   std::fstream fsOut;
   fsOut.open(argv[2], std::fstream::out | std::fstream::trunc);
 
-  // Header
-  fsOut << "#include <cstddef>\n#include <cstdint>\nnamespace google_myanmar_tools {\nconst uint8_t kModelData[] = {";
-  uint64_t modelSize = 0;
-
   for (std::istreambuf_iterator<char> it(fsIn), end; it != end; it++) {
     char c = *it;
     fsOut << "0x";
     fsOut << std::setw(2) << std::setfill('0') << std::hex
           << (+c & 0xFF);
     fsOut << ",";
-    modelSize++;
   }
 
-  // Footer
-  fsOut << "};\nconst size_t kModelSize = 0x";
-  fsOut << std::hex << modelSize;
-  fsOut << ";\n}\n";
+  fsOut << "\n";
 
   fsOut.close();
   fsIn.close();

--- a/clients/cpp/zawgyi_detector.cpp
+++ b/clients/cpp/zawgyi_detector.cpp
@@ -13,14 +13,22 @@
 // limitations under the License.
 
 #include <cmath>
-#include <limits>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <limits>
 #include <glog/logging.h>
 #include <unicode/utf8.h>
 
 #include "public/myanmartools.h"
 #include "zawgyi_detector-impl.h"
+
+namespace {
+const uint8_t kModelData[] = {
 #include "zawgyi_model_data.inc"
+};
+constexpr size_t kModelSize = sizeof kModelData;
+}  // namespace
 
 using namespace google_myanmar_tools;
 


### PR DESCRIPTION
Apart from resulting in a few lines less code in build_model_inc.cpp
this gets rid of the magic name kModelData that currently is defined in
the generated data file; moving the definition into zawgyi_detector.cpp
instead now makes it trivial to find what that name refers to.

Similarly for kModelSize which now can get a trivial definition directly
in zawgyi_detector.cpp, instead of needing build_model_inc.cpp to count
how many bytes it writes.